### PR TITLE
Add .bowerrc file to override global .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "bower_components",
+    "directory": "bower_components"
 }

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components",
+}


### PR DESCRIPTION
Adding `.bowerrc` to project folder ensures global config does not override project's preferred `bower_components` directory name.